### PR TITLE
Change unicode(x, encoding) to x.decode(encoding)

### DIFF
--- a/nototools/coverage.py
+++ b/nototools/coverage.py
@@ -39,7 +39,7 @@ def character_set(font):
   Returns:
     A frozenset listing the characters supported in the font.
   """
-  if type(font) is str:
+  if isinstance(font, str):
     font = ttLib.TTFont(font, fontNumber=0)
   cmap_table = font['cmap']
   cmaps = {}

--- a/nototools/dump_otl.py
+++ b/nototools/dump_otl.py
@@ -30,7 +30,7 @@ def internal_font_name(font):
         identifier = (record.nameID, record.platformID,
                       record.platEncID, record.langID)
         if identifier in [(4, 3, 1, 0x409), (4, 3, 0, 0x409)]:
-            return unicode(record.string, 'UTF-16BE')
+            return record.string.decode('UTF-16BE')
 
 
 def print_indented(output_string, indents=1):

--- a/nototools/fix_noto_cjk_thin.py
+++ b/nototools/fix_noto_cjk_thin.py
@@ -42,7 +42,7 @@ def fix_font(source_filename):
             assert record.platEncID == 1
             assert record.langID == 0x0409
             encoding = 'UTF-16BE'
-        value = unicode(record.string, encoding)
+        value = record.string.decode(encoding)
         if record.nameID == 3:
             original_version = value[:value.index(';')]
             new_version = original_version + '1'

--- a/nototools/font_data.py
+++ b/nototools/font_data.py
@@ -18,7 +18,6 @@
 
 __author__ = 'roozbeh@google.com (Roozbeh Pournader)'
 
-from nototools.py23 import unicode
 from nototools import opentype_data
 
 from fontTools.ttLib.tables._n_a_m_e import NameRecord
@@ -31,7 +30,7 @@ def get_name_records(font):
         name_ids = (record.platformID, record.platEncID, record.langID)
         if name_ids != (3, 1, 0x409):
             continue
-        names[record.nameID] = unicode(record.string, 'UTF-16BE')
+        names[record.nameID] = record.string.decode('UTF-16BE')
     return names
 
 

--- a/nototools/generate_samples.py
+++ b/nototools/generate_samples.py
@@ -18,7 +18,7 @@ import argparse
 import codecs
 import re
 
-from nototools.py23 import unichr, unicode
+from nototools.py23 import unichr
 
 """Generate samples from a description file."""
 
@@ -108,12 +108,6 @@ sequences within an group.
 # constants
 _LEAD_OFFSET = 0xD800 - (0x10000 >> 10)
 _SURROGATE_OFFSET = 0x10000 - (0xD800 << 10) - 0xDC00
-
-
-def cp_to_str(cp):
-  if cp < 0x10000:
-    return unichr(cp)
-  return unicode(r'\U%08X' % cp, encoding='unicode_escape')
 
 
 def surrogate_pair_to_cp(low, high):
@@ -292,11 +286,7 @@ def _unescape(arg):
     if unival > 0x10ffff:
       error = 'Unicode escape value too large: "%X"' % unival
       raise ValueError(error)
-    if unival < 0x10000:
-      prefix = unichr(unival)
-    else:
-      prefix = unicode(
-          '\\U%08X' % unival, encoding='unicode_escape', errors='strict')
+    prefix = unichr(unival)
     return prefix + esc_val[esc_len:]
 
   return _UNICODE_ESCAPE_RE.sub(sub, arg)
@@ -349,7 +339,7 @@ def _segments_to_strings(segments, prefix, result):
   segments = segments[1:]
   if type(segment) == tuple:
     for cp in range(segment[0], segment[1] + 1):
-      _segments_to_strings(segments, prefix + cp_to_str(cp), result)
+      _segments_to_strings(segments, prefix + unichr(cp), result)
   else:
     _segments_to_strings(segments, prefix + segment, result)
 

--- a/nototools/generate_website_2_data.py
+++ b/nototools/generate_website_2_data.py
@@ -37,7 +37,6 @@ import xml.etree.cElementTree as ElementTree
 
 from fontTools import ttLib
 
-from nototools.py23 import unicode
 from nototools import cldr_data
 from nototools import coverage
 from nototools import create_image
@@ -411,7 +410,7 @@ def get_sample_names_for_lang_scr_typ(lang_scr, typ):
 def get_sample_from_sample_file(lang_scr_typ):
   filepath = path.join(SAMPLE_TEXT_DIR, lang_scr_typ + '.txt')
   if path.exists(filepath):
-    return unicode(open(filepath).read().strip(), 'UTF-8')
+    return open(filepath).read().strip().decode('UTF-8')
   return None
 
 

--- a/nototools/generate_website_data.py
+++ b/nototools/generate_website_data.py
@@ -36,7 +36,7 @@ import xml.etree.cElementTree as ElementTree
 
 from fontTools import ttLib
 
-from nototools.py23 import unichr, unicode
+from nototools.py23 import unichr
 from nototools import coverage
 from nototools import create_image
 from nototools import extra_locale_data
@@ -298,7 +298,7 @@ def get_exemplar(language, script):
 def get_sample_from_sample_file(language, script):
     filepath = path.join(SAMPLE_TEXT_DIR, language+'-'+script+'.txt')
     if path.exists(filepath):
-        return unicode(open(filepath).read().strip(), 'UTF-8')
+        return open(filepath).read().strip().decode('UTF-8')
     return None
 
 

--- a/nototools/lint_cmap_reqs.py
+++ b/nototools/lint_cmap_reqs.py
@@ -19,7 +19,6 @@
 import argparse
 import sys
 
-from nototools.py23 import unicode
 from nototools import lint_config
 from nototools import noto_data
 from nototools import opentype_data
@@ -215,7 +214,7 @@ def main():
     sys.stderr.write('writing %s\n' % args.outfile)
     cmap_data.write_cmap_data_file(cmapdata, args.outfile, pretty=True)
   else:
-    print(unicode(cmap_data.write_cmap_data(cmapdata, pretty=True), "utf-8"))
+    print(cmap_data.write_cmap_data(cmapdata, pretty=True).decode("utf-8"))
 
 
 if __name__ == "__main__":

--- a/nototools/lint_config.py
+++ b/nototools/lint_config.py
@@ -127,10 +127,8 @@ def write_int_ranges(int_values, in_hex=True, sep=' '):
 
   num_list = []
 
-  if type(int_values) is not list:
-    int_values = [v for v in int_values]
-  int_values.sort()
-  start = prev = int_values[0]
+  int_values = iter(sorted(int_values))
+  start = prev = next(int_values)
   single_fmt = '%04x' if in_hex else '%d'
   pair_fmt = single_fmt + '-' + single_fmt
 
@@ -140,7 +138,7 @@ def write_int_ranges(int_values, in_hex=True, sep=' '):
     else:
       num_list.append(pair_fmt % (start, prev))
 
-  for v in int_values[1:]:
+  for v in int_values:
     if v == prev + 1:
       prev += 1
       continue

--- a/nototools/merge_noto.py
+++ b/nototools/merge_noto.py
@@ -17,7 +17,6 @@
 """Merges Noto fonts."""
 import os.path
 import tempfile
-from nototools.py23 import unicode
 
 from fontTools import merge
 from fontTools import ttLib
@@ -253,7 +252,7 @@ def main():
             first_font = source_fonts[0]
             if first_font != merge_target:
                 for name_record in font['name'].names:
-                    name = unicode(name_record.string, 'UTF-16BE')
+                    name = name_record.string.decode('UTF-16BE')
                     name = name.replace(make_font_name(first_font),
                                         make_font_name(merge_target))
                     name = name.replace(make_puncless_font_name(first_font),

--- a/nototools/noto_font_cmaps.py
+++ b/nototools/noto_font_cmaps.py
@@ -20,7 +20,6 @@ import argparse
 import collections
 import sys
 
-from nototools.py23 import unicode
 from nototools import cmap_data
 from nototools import lint_config
 from nototools import noto_fonts
@@ -133,7 +132,7 @@ def main():
   if args.outfile:
     cmap_data.write_cmap_data_file(cmapdata, args.outfile, pretty=True)
   else:
-    print(unicode(cmap_data.write_cmap_data(cmapdata, pretty=True), "utf-8"))
+    print(cmap_data.write_cmap_data(cmapdata, pretty=True).decode("utf-8"))
 
 
 if __name__ == "__main__":

--- a/nototools/test_vertical_extents.py
+++ b/nototools/test_vertical_extents.py
@@ -37,7 +37,7 @@ import re
 import sys
 import xml.etree.ElementTree
 
-from nototools.py23 import unichr, unicode
+from nototools.py23 import unichr
 from nototools import coverage
 from nototools import font_caching
 from nototools import render
@@ -103,7 +103,7 @@ def test_rendering_from_file(
 
     else:
         # Assume text file, with all the data as one large string
-        input_data = unicode(input_data, 'UTF-8')
+        input_data = input_data.decode('UTF-8')
 
     # Now, input_data is just a long string, with new lines as separators.
 

--- a/nototools/tool_utils.py
+++ b/nototools/tool_utils.py
@@ -519,10 +519,8 @@ def write_int_ranges(int_values, in_hex=True, sep=' '):
 
   num_list = []
 
-  if type(int_values) is not list:
-    int_values = [v for v in int_values]
-  int_values.sort()
-  start = prev = int_values[0]
+  int_values = iter(sorted(int_values))
+  start = prev = next(int_values)
   single_fmt = '%04x' if in_hex else '%d'
   pair_fmt = single_fmt + '-' + single_fmt
 
@@ -532,7 +530,7 @@ def write_int_ranges(int_values, in_hex=True, sep=' '):
     else:
       num_list.append(pair_fmt % (start, prev))
 
-  for v in int_values[1:]:
+  for v in int_values:
     if v == prev + 1:
       prev += 1
       continue

--- a/nototools/ttc_utils.py
+++ b/nototools/ttc_utils.py
@@ -25,7 +25,6 @@ import subprocess
 
 from fontTools.ttLib.tables._n_a_m_e import table__n_a_m_e as NameTable
 
-from nototools.py23 import unicode 
 from nototools import tool_utils
 
 _ttcHeader = '>4sLL'
@@ -171,7 +170,7 @@ def ttc_filenames(ttc, data):
       ps_name = None
       for r in name_table.names:
         if (r.nameID, r.platformID, r.platEncID, r.langID) == (6, 3, 1, 0x409):
-          ps_name = unicode(r.string, 'UTF-16BE')
+          ps_name = r.string.decode('UTF-16BE')
           break
       if ps_name:
         file_name = ps_name

--- a/nototools/unicode_data.py
+++ b/nototools/unicode_data.py
@@ -126,7 +126,7 @@ def name(char, *args):
   Raises a ValueError exception if the character is undefined, unless an
   extra argument is given, in which case it will return that argument.
   """
-  if type(char) is int:
+  if isinstance(char, int):
     char = unichr(char)
   # First try and get the name from unidata, which is faster and supports
   # CJK and Hangul automatic names
@@ -275,7 +275,7 @@ UNISCRIBE_USED_IGNORABLES = frozenset([0x115f, 0x1160, 0x3164, 0xffa0])
 def is_default_ignorable(char):
   """Returns true if the character has the Default_Ignorable property."""
   load_data()
-  if type(char) in [str, unicode]:
+  if isinstance(char, (str, unicode)):
     char = ord(char)
   return char in _core_properties_data["Default_Ignorable_Code_Point"]
 
@@ -287,7 +287,7 @@ def default_ignorables():
 def is_defined(char):
   """Returns true if the character is defined in the Unicode Standard."""
   load_data()
-  if type(char) in [str, unicode]:
+  if isinstance(char, (str, unicode)):
     char = ord(char)
   return char in _defined_characters
 
@@ -300,7 +300,7 @@ def is_private_use(char):
 def mirrored(char):
   """Returns 1 if the characters is bidi mirroring, 0 otherwise."""
   load_data()
-  if type(char) in [str, unicode]:
+  if isinstance(char, (str, unicode)):
     char = ord(char)
   return int(char in _bidi_mirroring_characters)
 
@@ -308,7 +308,7 @@ def mirrored(char):
 def bidi_mirroring_glyph(char):
   """Returns the bidi mirroring glyph property of a character."""
   load_data()
-  if type(char) in [str, unicode]:
+  if isinstance(char, (str, unicode)):
     char = ord(char)
   try:
     return _bidi_mirroring_glyph_data[char]
@@ -323,7 +323,7 @@ def mirrored_chars():
 def indic_positional_category(char):
   """Returns the Indic positional category of a character."""
   load_data()
-  if type(char) in [str, unicode]:
+  if isinstance(char, (str, unicode)):
     char = ord(char)
   try:
     return _indic_positional_data[char]
@@ -334,7 +334,7 @@ def indic_positional_category(char):
 def indic_syllabic_category(char):
   """Returns the Indic syllabic category of a character."""
   load_data()
-  if type(char) in [str, unicode]:
+  if isinstance(char, (str, unicode)):
     char = ord(char)
   try:
     return _bidi_syllabic_data[char]

--- a/nototools/update_udhr_samples.py
+++ b/nototools/update_udhr_samples.py
@@ -35,7 +35,6 @@ except:
 
 import xml.etree.ElementTree as ET
 
-from nototools.py23 import unicode
 from nototools import generate_website_data
 from nototools import tool_utils
 from nototools import unicode_data
@@ -699,7 +698,7 @@ def get_scripts(text):
   exclusions = {0x00, 0x0A, 0x0D, 0x20, 0xA0, 0xFEFF}
   zyyy_chars = set()
   scripts = set()
-  ustr = unicode(text, 'utf8')
+  ustr = text.decode('utf8')
   for cp in ustr:
     if ord(cp) in exclusions:
       continue


### PR DESCRIPTION
This new syntax is now supported both in python 3 and python 2. This change slightly reduces the code (one import less in many files) and introduces a better practice in type checking (`isinstance(..., ...)` instead of `type(...) is ...`).

Also `unichr()` now supports all possible code points, so there is no need for special cases with code points >= `0x10000`.

The updated code also makes use of iterators, which are implemented less memory-intensive.