### PR TITLE
Remove python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 language: python
 dist: xenial
 python:
-  - "2.7"
   - "3.7"
 branches:
   only:

--- a/nototools/docker/toolbase/basesetup.sh
+++ b/nototools/docker/toolbase/basesetup.sh
@@ -25,10 +25,10 @@ make install NO_GETTEXT=1
 hash git
 
 # patch lookup path so our python in /usr/local/lib can find pango in /usr/lib
-cat << EOF >> /usr/local/lib/python2.7/sitecustomize.py
+cat << EOF >> /usr/local/lib/python3.7/sitecustomize.py
 import sys
-sys.path.append('/usr/lib/python2.7/dist-packages')
-sys.path.append('/usr/lib/python2.7/dist-packages/gtk-2.0')
+sys.path.append('/usr/lib/python3.7/dist-packages')
+sys.path.append('/usr/lib/python3.7/dist-packages/gtk-2.0')
 EOF
 
 # for harfbuzz

--- a/third_party/spiro/x3/pyrex/Makefile
+++ b/third_party/spiro/x3/pyrex/Makefile
@@ -28,7 +28,7 @@ x3.so:	x3.o x3$(TARGET).o x3common.o
 	gcc $(SHARED_FLAG) $^ $(X3_LIBS) -o $@
 
 x3.c:	x3.pyx
-	python2.4-pyrexc $<
+	python-pyrexc $<
 
 x3$(TARGET).o:	../x3$(TARGET).c
 	$(CC) -c $(CFLAGS) -o $@ $<


### PR DESCRIPTION
This removes python2 due the stopped support.

> DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.