### PR TITLE
Fix generate_website_2_data.py — [Work In Progess, do not merge]

### DIFF
--- a/nototools/generate_website_2_data.py
+++ b/nototools/generate_website_2_data.py
@@ -470,7 +470,7 @@ def get_sample_names_for_lang_scr_typ(lang_scr, typ):
 def get_sample_from_sample_file(lang_scr_typ):
     filepath = path.join(SAMPLE_TEXT_DIR, lang_scr_typ + ".txt")
     if path.exists(filepath):
-        return open(filepath).read().strip().decode("UTF-8")
+        return open(filepath).read().strip()
     return None
 
 

--- a/nototools/lang_data.py
+++ b/nototools/lang_data.py
@@ -115,7 +115,7 @@ def _create_lang_data():
     # Patch: see noto-fonts#133 comment on June 8th.
     all_lang_scripts["tlh"] |= {"Latn", "Piqd"}
 
-    all_langs = used_lang_scripts.keys() + all_lang_scripts.keys()
+    all_langs = list(used_lang_scripts) + list(all_lang_scripts)
     lang_data = {}
     for lang in all_langs:
         if lang in used_lang_scripts:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ fs==2.4.11
 lxml==4.6.2
 MutatorMath==3.0.1
 pathspec==0.8.0
-Pillow==7.1.2
+Pillow==8.0.1
 psautohint==2.0.1
-pyclipper==1.1.0.post1
+pyclipper==1.2.1
 pytz==2020.1
 regex==2020.5.14
 scour==0.37


### PR DESCRIPTION
As requested by @davelab6 I'm trying to fix `./nototools/generate_website_2_data.py`. This was mostly Python 2 → Python 3, and translating old Pango/Cairo to their newer syntax.

There are a few things I couldn't resolve, so I'm opening this PR so I can ask for help :-)

Please note that the first commit is basically https://github.com/googlefonts/nototools/pull/531, which is needed to make this run on macOS.

- [ ] Pango language, https://github.com/googlefonts/nototools/pull/532/commits/e8e82e928de8159e8fc0419ff28ad0a265deefa0#diff-7617d1cc6cb0952747415afd3f54b2519536d935e7317bce5a35992dc34c2cfbR152 gives `TypeError: boxed cannot be created directly; try using a constructor, see: help(Pango.Language)`
- [ ] Margins, https://github.com/googlefonts/nototools/pull/532/commits/e8e82e928de8159e8fc0419ff28ad0a265deefa0#diff-7617d1cc6cb0952747415afd3f54b2519536d935e7317bce5a35992dc34c2cfbR242 gives `TypeError: 'Rectangle' object is not subscriptable`
- [ ] Top/bottom usage, https://github.com/googlefonts/nototools/pull/532/commits/e8e82e928de8159e8fc0419ff28ad0a265deefa0#diff-7617d1cc6cb0952747415afd3f54b2519536d935e7317bce5a35992dc34c2cfbR259 gives `TypeError: 'Rectangle' object is not subscriptable`
- [ ] Show layout, https://github.com/googlefonts/nototools/pull/532/commits/e8e82e928de8159e8fc0419ff28ad0a265deefa0#diff-7617d1cc6cb0952747415afd3f54b2519536d935e7317bce5a35992dc34c2cfbR275 gives `AttributeError: 'cairo.Context' object has no attribute 'show_layout'`

The first errors van be ignored/worked around, but the last one is needed to actually render something. If the `show_layout` step is ignored, rendering to PNG doesn't work.