### PR TITLE
Add 'b' to the prefix to compare Bytes literals

### DIFF
--- a/nototools/ttc_utils.py
+++ b/nototools/ttc_utils.py
@@ -63,7 +63,7 @@ class TTCFile(object):
 
     def _build(self, data):
         tag, version, font_count = struct.unpack(_ttcHeader, data[:_ttcHeaderSize])
-        if tag not in ["ttcf"]:
+        if tag not in [b"ttcf"]:
             raise ValueError("not a font collection")
         if version not in [0x10000, 0x20000]:
             raise ValueError("unrecognized version %s" % version)
@@ -164,7 +164,7 @@ def ttc_filenames(ttc, data):
         name_entry = None
         file_name = None
         for ix in font_entry.tables:
-            if ttc.tables[ix].tag == "name":
+            if ttc.tables[ix].tag == b"name":
                 name_entry = ttc.tables[ix]
                 break
         if name_entry:


### PR DESCRIPTION
> Bytes literals are always prefixed with 'b' or 'B'; they produce an instance of the `bytes` type instead of the `str` type. They may only contain ASCII characters; bytes with a numeric value of 128 or greater must be expressed with escapes.

https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
https://stackoverflow.com/questions/6269765/what-does-the-b-character-do-in-front-of-a-string-literal