### PR TITLE
Change ttc_utils.py to use `fonttools` instead of `AFDKO`

### DIFF
--- a/nototools/ttc_utils.py
+++ b/nototools/ttc_utils.py
@@ -89,20 +89,16 @@ def ttc_filenames(ttc):
 
 
 def ttfont_filename(font):
-    font_fmt = ttfont_format_as_extension(font)
     name_table = font.get("name")
     if name_table:
-        ps_name = None
-        for r in name_table.names:
-            if (r.nameID, r.platformID, r.platEncID, r.langID) == (6, 3, 1, 0x409):
-                ps_name = r.string.decode("UTF-16BE")
-                break
+        ps_name = name_table.getDebugName(6)
         if ps_name:
             file_name = ps_name
             if "-" not in ps_name:
                 file_name += "-Regular"
+            font_fmt = ttfont_format_as_extension(font)
             file_name += "." + font_fmt
-    return file_name
+    return None
 
 
 def ttfont_format_as_extension(font):

--- a/nototools/ttc_utils.py
+++ b/nototools/ttc_utils.py
@@ -98,6 +98,7 @@ def ttfont_filename(font):
                 file_name += "-Regular"
             font_fmt = ttfont_format_as_extension(font)
             file_name += "." + font_fmt
+            return file_name
     return None
 
 


### PR DESCRIPTION
This patch changes the implementation of `ttc_utils.py` by
using `fonttools` instead of `AFDKO`.

This is the approach 2 mentioned in #537.